### PR TITLE
Webkit/Chrome requires xhr to be open before setting headers

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -8,6 +8,8 @@ var Request = module.exports = function (xhr, params) {
     
     var uri = params.host + ':' + params.port + (params.path || '/');
     
+    xhr.open(params.method || 'GET', 'http://' + uri, true);
+    
     if (params.headers) {
         Object.keys(params.headers).forEach(function (key) {
             var value = params.headers[key];
@@ -19,8 +21,6 @@ var Request = module.exports = function (xhr, params) {
             else xhr.setRequestHeader(key, value)
         });
     }
-    
-    xhr.open(params.method || 'GET', 'http://' + uri, true);
     
     var res = new Response;
     res.on('ready', function () {


### PR DESCRIPTION
At least this seemed be the case in my browser
