### PR TITLE
Typo fix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,7 +116,7 @@ You can do:
 
 ````javascript
 var bundle = browserify({
-    require : { http : 'http-require' }
+    require : { http : 'http-browserify' }
 });
 ````
 


### PR DESCRIPTION
I was chasing around a bug in what I thought was my setup with browserify but it turned out to be a typo in the readme:

```
var bundle = browserify({
    require : { http : 'http-require' }
});
```

Should be:

```
var bundle = browserify({
    require : { http : 'http-browserify' }
});
```
