### PR TITLE
parameterize the url scheme in http-browserify

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -8,7 +8,9 @@ var Request = module.exports = function (xhr, params) {
     
     var uri = params.host + ':' + params.port + (params.path || '/');
     
-    xhr.open(params.method || 'GET', 'http://' + uri, true);
+    xhr.open( params.method || 'GET',
+        (params.scheme || 'http') + '://' + uri,
+        true);
     
     if (params.headers) {
         Object.keys(params.headers).forEach(function (key) {


### PR DESCRIPTION
I need to make requests to an site with HTTPS.

Since the browser handles all the SSL heavy lifting, http-browserify is able to make HTTPS connections.

This patch allows the user to pass in a scheme, and http-browserify will use the scheme if it has one, otherwise it will default to http.
