### PR TITLE
check for unsafe headers before setting header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -16,6 +16,7 @@ var Request = module.exports = function (xhr, params) {
     
     if (params.headers) {
         Object.keys(params.headers).forEach(function (key) {
+            if (!self.isSafeRequestHeader(key)) return;
             var value = params.headers[key];
             if (Array.isArray(value)) {
                 value.forEach(function (v) {
@@ -57,4 +58,36 @@ Request.prototype.write = function (s) {
 Request.prototype.end = function (s) {
     if (s !== undefined) this.write(s);
     this.xhr.send(this.body);
+};
+
+Request.prototype.isSafeRequestHeader = function (headerName) {
+  if (!headerName) return false;
+  headerName = headerName.toLowerCase();
+
+  // Taken from http://dxr.mozilla.org/mozilla/mozilla-central/content/base/src/nsXMLHttpRequest.cpp.html
+  var unsafeHeaders = [
+      "accept-charset",
+      "accept-encoding",
+      "access-control-request-headers",
+      "access-control-request-method",
+      "connection",
+      "content-length",
+      "cookie",
+      "cookie2",
+      "content-transfer-encoding",
+      "date",
+      "expect",
+      "host",
+      "keep-alive",
+      "origin",
+      "referer",
+      "te",
+      "trailer",
+      "transfer-encoding",
+      "upgrade",
+      "user-agent",
+      "via"
+  ];
+
+  return (unsafeHeaders.indexOf(headerName) === -1)
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -60,34 +60,32 @@ Request.prototype.end = function (s) {
     this.xhr.send(this.body);
 };
 
+// Taken from http://dxr.mozilla.org/mozilla/mozilla-central/content/base/src/nsXMLHttpRequest.cpp.html
+Request.unsafeHeaders = [
+    "accept-charset",
+    "accept-encoding",
+    "access-control-request-headers",
+    "access-control-request-method",
+    "connection",
+    "content-length",
+    "cookie",
+    "cookie2",
+    "content-transfer-encoding",
+    "date",
+    "expect",
+    "host",
+    "keep-alive",
+    "origin",
+    "referer",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "user-agent",
+    "via"
+];
+
 Request.prototype.isSafeRequestHeader = function (headerName) {
-  if (!headerName) return false;
-  headerName = headerName.toLowerCase();
-
-  // Taken from http://dxr.mozilla.org/mozilla/mozilla-central/content/base/src/nsXMLHttpRequest.cpp.html
-  var unsafeHeaders = [
-      "accept-charset",
-      "accept-encoding",
-      "access-control-request-headers",
-      "access-control-request-method",
-      "connection",
-      "content-length",
-      "cookie",
-      "cookie2",
-      "content-transfer-encoding",
-      "date",
-      "expect",
-      "host",
-      "keep-alive",
-      "origin",
-      "referer",
-      "te",
-      "trailer",
-      "transfer-encoding",
-      "upgrade",
-      "user-agent",
-      "via"
-  ];
-
-  return (unsafeHeaders.indexOf(headerName) === -1)
+    if (!headerName) return false;
+    return (Request.unsafeHeaders.indexOf(headerName.toLowerCase()) === -1)
 };


### PR DESCRIPTION
Using http-browserify, my console was flooded with messages like this:

```
Refused to set unsafe header "Content-Length"
Refused to set unsafe header "User-Agent"
```

There are some "unsafe" headers that we cannot set on an XHR.   

This is poorly documented, but I found Mozilla's list of unsafe headers here:
http://dxr.mozilla.org/mozilla/mozilla-central/content/base/src/nsXMLHttpRequest.cpp.html

And I found Webkit's list of unsafe headers here:
http://opensource.apple.com/source/WebCore/WebCore-5525.28.4/xml/XMLHttpRequest.cpp

This commit makes sure we don't call `xhr.setRequestHeader` on an unsafe header.  I used the Mozilla list because it is a superset of the Webkit list.
