### PR TITLE
Change getResponse to return xhr.response if responseType == 'blob' and ...

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -45,7 +45,7 @@ function parseHeaders (res) {
 
 Response.prototype.getResponse = function (xhr) {
     var respType = String(xhr.responseType).toLowerCase();
-    if (respType === 'blob') return xhr.responseBlob;
+    if (respType === 'blob') return xhr.responseBlob || xhr.response;
     if (respType === 'arraybuffer') return xhr.response;
     return xhr.responseText;
 }


### PR DESCRIPTION
...responseBlob doesn't exist

responseBlob doesn't exist in the latest Chrome. I'm thinking responseBlob is deprecated, as it was part of the deprecated BlobBuilder API
