### PR TITLE
Default to using the scheme of the current page

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ http.request = function (params, cb) {
     if (!params) params = {};
     if (!params.host) params.host = window.location.host.split(':')[0];
     if (!params.port) params.port = window.location.port;
+    if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
     
     var req = new Request(new xhrHttp, params);
     if (cb) req.on('response', cb);


### PR DESCRIPTION
Otherwise pages that work when accessed from `http` don't work when accessed from `https` because they suddenly start attempting cross domain access.
