### PR TITLE
http options.auth use Buffer function rather than Buffer object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
 var Stream = require('stream');
 var Response = require('./response');
 var concatStream = require('concat-stream')
-var Buffer = require('buffer')
+var Buffer = require('buffer').Buffer
 
 var Request = module.exports = function (xhr, params) {
     var self = this;


### PR DESCRIPTION
This PR seems to fix this issue: https://github.com/substack/node-browserify/issues/442

isBuffer used by level-js solves it this way ( github.com/juliangruber/isbuffer )
