### PR TITLE
prevent buffer-browserify from getting included to reduce bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
 var Stream = require('stream');
 var Response = require('./response');
-var concatStream = require('concat-stream')
-var Buffer = require('buffer')
+var concatStream = require('concat-stream');
+var Base64 = require('Base64');
 
 var Request = module.exports = function (xhr, params) {
     var self = this;
@@ -37,7 +37,7 @@ var Request = module.exports = function (xhr, params) {
     
     if (params.auth) {
         //basic auth
-        this.setHeader('Authorization', 'Basic ' + new Buffer(params.auth).toString('base64'));
+        this.setHeader('Authorization', 'Basic ' + Base64.btoa(params.auth));
     }
 
     var res = new Response;

--- a/package.json
+++ b/package.json
@@ -1,36 +1,39 @@
 {
-    "name" : "http-browserify",
-    "version" : "0.1.11",
-    "description" : "http module compatability for browserify",
-    "main" : "index.js",
-    "browserify" : "index.js",
-    "directories" : {
-        "lib" : ".",
-        "example" : "example",
-        "test" : "test"
-    },
-    "dependencies": {
-        "concat-stream": "0.0.8"
-    },
-    "devDependencies" : {
-        "ecstatic" : "~0.1.6"
-    },
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/substack/http-browserify.git"
-    },
-    "keywords" : [
-        "http",
-        "browserify",
-        "compatible",
-        "meatless",
-        "browser"
-    ],
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "license" : "MIT/X11",
-    "engine" : { "node" : ">=0.4" }
+  "name": "http-browserify",
+  "version": "0.1.11",
+  "description": "http module compatability for browserify",
+  "main": "index.js",
+  "browserify": "index.js",
+  "directories": {
+    "lib": ".",
+    "example": "example",
+    "test": "test"
+  },
+  "dependencies": {
+    "concat-stream": "~1.0.0",
+    "Base64": "~0.1.2"
+  },
+  "devDependencies": {
+    "ecstatic": "~0.1.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/substack/http-browserify.git"
+  },
+  "keywords": [
+    "http",
+    "browserify",
+    "compatible",
+    "meatless",
+    "browser"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "license": "MIT/X11",
+  "engine": {
+    "node": ">=0.4"
+  }
 }


### PR DESCRIPTION
this uses the `Base64` module which is a smaller implementation than the previously used buffer-browserify one

it also upgrades `concat-stream` which now uses `bops.is` to check for bufferness instead of the previous `Buffer.isBuffer` which caused buffer-browserify to get included

before:

``` sh
browserify index.js | wc -c
   86428
```

after:

``` sh
browserify index.js | wc -c
   45525
```
