### PR TITLE
Check for undefined port when assigning default

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var Request = require('./lib/request');
 http.request = function (params, cb) {
     if (!params) params = {};
     if (!params.host) params.host = window.location.host.split(':')[0];
-    if (!params.port) params.port = window.location.port;
+    if (typeof params.port === 'undefined') params.port = window.location.port;
     if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
     
     var req = new Request(new xhrHttp, params);


### PR DESCRIPTION
`lib/request` builds the uri based on a falsey port (it won't append a
port number if there isn't one), but this case makes it difficult to
test cross domain requests when running on a non standard port number
since it's always defaulting to `window.location.port`.
