### PR TITLE
full support for node url object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Request = require('./lib/request');
 
 http.request = function (params, cb) {
     if (!params) params = {};
-    if (!params.host) params.host = window.location.host.split(':')[0];
+    if (!params.host) params.host = window.location.host;
     if (!params.port) params.port = window.location.port;
     if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
     

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,16 +8,21 @@ var Request = module.exports = function (xhr, params) {
     var self = this;
     self.writable = true;
     self.xhr = xhr;
-    self.body = concatStream()
+    self.body = concatStream();
+
+    if (!params.host && params.hostname) {
+        params.host = params.hostname + (params.port ? ':' + params.port : '');
+    }
     
-    var uri = params.host
-        + (params.port ? ':' + params.port : '')
+    self.uri = 
+        (params.scheme || 'http') + '://'
+        + params.host
         + (params.path || '/')
     ;
-    
+
     xhr.open(
         params.method || 'GET',
-        (params.scheme || 'http') + '://' + uri,
+        self.uri,
         true
     );
     

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Base64": "~0.1.2"
   },
   "devDependencies": {
-    "ecstatic": "~0.1.6"
+    "ecstatic": "~0.1.6",
+    "tape": "~1.1.1"
   },
   "repository": {
     "type": "git",
@@ -35,5 +36,8 @@
   "license": "MIT/X11",
   "engine": {
     "node": ">=0.4"
+  },
+  "scripts": {
+    "test": "tape tests/*.js"
   }
 }

--- a/tests/request_url.js
+++ b/tests/request_url.js
@@ -1,0 +1,49 @@
+global.window = {
+  location: {
+    host: 'localhost:8081',
+    port: 8081,
+    protocol: 'http:'
+  }
+};
+
+var noop = function() {};
+global.window.XMLHttpRequest = function() {
+  this.open = noop;
+  this.send = noop;
+};
+
+var test = require('tape').test;
+var http = require('../index.js');
+
+
+test('Test simple url string', function(t) {
+  var url = { path: '/api/foo' };
+  var request = http.get(url, noop);
+
+  t.equal( request.uri, 'http://localhost:8081/api/foo', 'Url should be correct');
+  t.end();
+
+});
+
+
+test('Test full url object', function(t) {
+  var url = { 
+    host: "localhost:8081",
+    hostname: "localhost",
+    href: "http://localhost:8081/api/foo?bar=baz",
+    method: "GET",
+    path: "/api/foo?bar=baz",
+    pathname: "/api/foo",
+    port: "8081",
+    protocol: "http:",
+    query: "bar=baz",
+    search: "?bar=baz",
+    slashes: true
+  };
+
+  var request = http.get(url, noop);
+
+  t.equal( request.uri, 'http://localhost:8081/api/foo?bar=baz', 'Url should be correct');
+  t.end();
+
+});


### PR DESCRIPTION
Fixed this issue - https://github.com/substack/http-browserify/issues/27

Attached uri to the Request instance so that I could write a few unit tests.  Added unit tests for simple case and for full node url object.

Please let me know if there is anything further I can do.
