### PR TITLE
Fix XHR support for (CORS) digest auth

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -15,6 +15,8 @@ var Request = module.exports = function (xhr, params) {
         + (params.path || '/')
     ;
     
+    xhr.withCredentials = true;
+    
     xhr.open(
         params.method || 'GET',
         (params.scheme || 'http') + '://' + uri,


### PR DESCRIPTION
We need to make authenticated cross site requests, using digest auth, with your lib, which isn't supported, at this moment.
