### PR TITLE
Remove Base64 dep

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,5 @@
 var Stream = require('stream');
 var Response = require('./response');
-var Base64 = require('Base64');
 var inherits = require('inherits');
 
 var Request = module.exports = function (xhr, params) {
@@ -40,7 +39,7 @@ var Request = module.exports = function (xhr, params) {
     
     if (params.auth) {
         //basic auth
-        this.setHeader('Authorization', 'Basic ' + Base64.btoa(params.auth));
+        this.setHeader('Authorization', 'Basic ' + window.btoa(params.auth));
     }
 
     var res = new Response;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "test"
   },
   "dependencies": {
-    "Base64": "~0.1.2",
     "inherits": "~2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Base64 provides an implementation of `window.btoa` and `window.atob`, but all modern browsers already support this, so let's just use it directly.

Base64 was only adding support for IE9 and lower, and `http-browserify` already won’t work in those browsers since it includes `stream` which includes `Buffer` which requires Uint8Array (not supported in IE9 and lower).

This also saves 3KB on bundle size.
