### PR TITLE
Make `withCredentials` a param allowing caller to set

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -15,7 +15,11 @@ var Request = module.exports = function (xhr, params) {
         + (params.path || '/')
     ;
     
-    try { xhr.withCredentials = true }
+    if (typeof params.withCredentials === 'undefined') {
+        params.withCredentials = true;
+    }
+
+    try { xhr.withCredentials = params.withCredentials }
     catch (e) {}
     
     xhr.open(

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -56,4 +56,19 @@ test('Test string as parameters', function(t) {
   t.equal( request.uri, 'http://localhost:8081/api/foo', 'Url should be correct');
   t.end();
 
-})
+});
+
+test('Test withCredentials param', function(t) {
+  var url = '/api/foo';
+
+  var request = http.request({ url: url, withCredentials: false }, noop);
+  t.equal( request.xhr.withCredentials, false, 'xhr.withCredentials should be false');
+
+  var request = http.request({ url: url, withCredentials: true }, noop);
+  t.equal( request.xhr.withCredentials, true, 'xhr.withCredentials should be true');
+
+  var request = http.request({ url: url }, noop);
+  t.equal( request.xhr.withCredentials, true, 'xhr.withCredentials should be true');
+
+  t.end();
+});


### PR DESCRIPTION
Wasn't sure if there was a solid reason for forcing `withCredentials` to be true and thought it would be useful to make a param. I am working with a server that doesn't support the credentials header.
