### PR TITLE
Use 'global' instead of window. Fixes #36

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,15 +9,15 @@ http.request = function (params, cb) {
     }
     if (!params) params = {};
     if (!params.host && !params.port) {
-        params.port = parseInt(window.location.port, 10);
+        params.port = parseInt(global.location.port, 10);
     }
     if (!params.host && params.hostname) {
         params.host = params.hostname;
     }
     
-    if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
+    if (!params.scheme) params.scheme = global.location.protocol.split(':')[0];
     if (!params.host) {
-        params.host = window.location.hostname || window.location.host;
+        params.host = global.location.hostname || global.location.host;
     }
     if (/:/.test(params.host)) {
         if (!params.port) {
@@ -43,13 +43,13 @@ http.Agent = function () {};
 http.Agent.defaultMaxSockets = 4;
 
 var xhrHttp = (function () {
-    if (typeof window === 'undefined') {
-        throw new Error('no window object present');
+    if (typeof global === 'undefined') {
+        throw new Error('no global object present');
     }
-    else if (window.XMLHttpRequest) {
-        return window.XMLHttpRequest;
+    else if (global.XMLHttpRequest) {
+        return global.XMLHttpRequest;
     }
-    else if (window.ActiveXObject) {
+    else if (global.ActiveXObject) {
         var axs = [
             'Msxml2.XMLHTTP.6.0',
             'Msxml2.XMLHTTP.3.0',
@@ -57,7 +57,7 @@ var xhrHttp = (function () {
         ];
         for (var i = 0; i < axs.length; i++) {
             try {
-                var ax = new(window.ActiveXObject)(axs[i]);
+                var ax = new(global.ActiveXObject)(axs[i]);
                 return function () {
                     if (ax) {
                         var ax_ = ax;
@@ -65,7 +65,7 @@ var xhrHttp = (function () {
                         return ax_;
                     }
                     else {
-                        return new(window.ActiveXObject)(axs[i]);
+                        return new(global.ActiveXObject)(axs[i]);
                     }
                 };
             }

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -1,13 +1,11 @@
-global.window = {
-  location: {
-    host: 'localhost:8081',
-    port: 8081,
-    protocol: 'http:'
-  }
+global.location = {
+  host: 'localhost:8081',
+  port: 8081,
+  protocol: 'http:'
 };
 
 var noop = function() {};
-global.window.XMLHttpRequest = function() {
+global.XMLHttpRequest = function() {
   this.open = noop;
   this.send = noop;
 };


### PR DESCRIPTION
`global` is provided by browserify to be `window` in normal windows or `self` in workers

Fixes #36 
