### PR TITLE
delay opening of XHR object until next tick

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -18,32 +18,39 @@ var Request = module.exports = function (xhr, params) {
     try { xhr.withCredentials = true }
     catch (e) {}
     
-    xhr.open(
-        params.method || 'GET',
-        self.uri,
-        true
-    );
-    
-    if (params.headers) {
-        var keys = objectKeys(params.headers);
-        for (var i = 0; i < keys.length; i++) {
-            var key = keys[i];
-            if (!self.isSafeRequestHeader(key)) continue;
-            var value = params.headers[key];
-            if (isArray(value)) {
-                for (var j = 0; j < value.length; j++) {
-                    xhr.setRequestHeader(key, value[j]);
+    self._open = function () {
+        xhr.open(
+            params.method || 'GET',
+            self.uri,
+            true
+        );
+        
+        if (params.headers) {
+            var keys = objectKeys(params.headers);
+            for (var i = 0; i < keys.length; i++) {
+                var key = keys[i];
+                if (!self.isSafeRequestHeader(key)) continue;
+                var value = params.headers[key];
+                if (isArray(value)) {
+                    for (var j = 0; j < value.length; j++) {
+                        xhr.setRequestHeader(key, value[j]);
+                    }
                 }
+                else xhr.setRequestHeader(key, value)
             }
-            else xhr.setRequestHeader(key, value)
         }
-    }
-    
-    if (params.auth) {
-        //basic auth
-        this.setHeader('Authorization', 'Basic ' + Base64.btoa(params.auth));
-    }
 
+        if (params.auth) {
+            //basic auth
+            self.setHeader(
+                'Authorization',
+                'Basic ' + Base64.btoa(params.auth)
+            );
+        }
+
+        self.emit('open', xhr)
+    };
+  
     var res = new Response;
     res.on('close', function () {
         self.emit('close');
@@ -72,6 +79,9 @@ Request.prototype.setHeader = function (key, value) {
 };
 
 Request.prototype.write = function (s) {
+    if (this.xhr.readyState === 0) {
+        this._open();
+    }
     this.body.push(s);
 };
 
@@ -82,6 +92,9 @@ Request.prototype.destroy = function (s) {
 
 Request.prototype.end = function (s) {
     if (s !== undefined) this.body.push(s);
+    if (this.xhr.readyState === 0) {
+        this._open();
+    }
     if (this.body.length === 0) {
         this.xhr.send('');
     }


### PR DESCRIPTION
The use case for this is to allow attaching event listeners to `"progress"` events. Listeners that are attached to this event _after_ open has been called (when the request is in `readyState === 1`) are ignored, so receiving progress events with requests made via `require('http').request` was impossible.
