### PR TITLE
Add request.getHeader and request.removeHeader

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -23,6 +23,8 @@ var Request = module.exports = function (xhr, params) {
         self.uri,
         true
     );
+
+    self._headers = {};
     
     if (params.headers) {
         var keys = objectKeys(params.headers);
@@ -30,12 +32,7 @@ var Request = module.exports = function (xhr, params) {
             var key = keys[i];
             if (!self.isSafeRequestHeader(key)) continue;
             var value = params.headers[key];
-            if (isArray(value)) {
-                for (var j = 0; j < value.length; j++) {
-                    xhr.setRequestHeader(key, value[j]);
-                }
-            }
-            else xhr.setRequestHeader(key, value)
+            self.setHeader(key, value);
         }
     }
     
@@ -61,14 +58,15 @@ var Request = module.exports = function (xhr, params) {
 inherits(Request, Stream);
 
 Request.prototype.setHeader = function (key, value) {
-    if (isArray(value)) {
-        for (var i = 0; i < value.length; i++) {
-            this.xhr.setRequestHeader(key, value[i]);
-        }
-    }
-    else {
-        this.xhr.setRequestHeader(key, value);
-    }
+    this._headers[key.toLowerCase()] = value
+};
+
+Request.prototype.getHeader = function (key) {
+    return this._headers[key.toLowerCase()]
+};
+
+Request.prototype.removeHeader = function (key) {
+    delete this._headers[key.toLowerCase()]
 };
 
 Request.prototype.write = function (s) {
@@ -82,6 +80,19 @@ Request.prototype.destroy = function (s) {
 
 Request.prototype.end = function (s) {
     if (s !== undefined) this.body.push(s);
+
+    var keys = objectKeys(this._headers);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var value = this._headers[key];
+        if (isArray(value)) {
+            for (var j = 0; j < value.length; j++) {
+                this.xhr.setRequestHeader(key, value[j]);
+            }
+        }
+        else this.xhr.setRequestHeader(key, value)
+    }
+
     if (this.body.length === 0) {
         this.xhr.send('');
     }

--- a/readme.markdown
+++ b/readme.markdown
@@ -66,6 +66,16 @@ req.setHeader(key, value)
 
 Set an http header.
 
+req.getHeader(key)
+-------------------------
+
+Get an http header.
+
+req.removeHeader(key)
+-------------------------
+
+Remove an http header.
+
 req.write(data)
 ---------------
 


### PR DESCRIPTION
Node exposes functions to get and remove request headers. They are mentioned [here](http://nodejs.org/api/http.html#http_class_http_clientrequest). The xhr object doesn't expose similar functions so I had to introduce the `_headers` object and shift a few code blocks around.
