### PR TITLE
replace params.scheme with params.protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ http.request = function (params, cb) {
         params.host = params.hostname;
     }
     
-    if(!params.protocol) params.protocol = window.location.protocol;
+    if (!params.protocol) {
+        params.protocol = params.scheme || window.location.protocol;
+        if (!/:$/.test(params.protocol)) params.protocol += ':';
+    }
 
     if (!params.host) {
         params.host = window.location.hostname || window.location.host;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ http.request = function (params, cb) {
         params.host = params.hostname;
     }
     
-    if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
+    if(!params.protocol) params.protocol = window.location.protocol;
+
     if (!params.host) {
         params.host = window.location.hostname || window.location.host;
     }
@@ -25,7 +26,7 @@ http.request = function (params, cb) {
         }
         params.host = params.host.split(':')[0];
     }
-    if (!params.port) params.port = params.scheme == 'https' ? 443 : 80;
+    if (!params.port) params.port = params.protocol == 'https:' ? 443 : 80;
     
     var req = new Request(new xhrHttp, params);
     if (cb) req.on('response', cb);

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,7 +9,7 @@ var Request = module.exports = function (xhr, params) {
     self.xhr = xhr;
     self.body = [];
     
-    self.uri = (params.scheme || 'http') + '://'
+    self.uri = (params.protocol || 'http:') + '//'
         + params.host
         + (params.port ? ':' + params.port : '')
         + (params.path || '/')


### PR DESCRIPTION
When passing an url string to https-browserify, a http request was send off. This commit simplifies the code and fixes that bug.
