### PR TITLE
Make sure to not call res.handle in case the request was aborted in IE9

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -55,6 +55,10 @@ var Request = module.exports = function (xhr, params) {
     });
     
     xhr.onreadystatechange = function () {
+        // Fix for IE9 bug
+        // SCRIPT575: Could not complete the operation due to error c00c023f
+        // It happens when a request is aborted, calling the success callback anyway with readyState === 4
+        if (xhr.__aborted) return;
         res.handle(xhr);
     };
 };
@@ -78,6 +82,7 @@ Request.prototype.write = function (s) {
 };
 
 Request.prototype.destroy = function (s) {
+    this.xhr.__aborted = true;
     this.xhr.abort();
     this.emit('close');
 };


### PR DESCRIPTION
This PR solves an issue documented in http://stackoverflow.com/questions/7287706/ie-9-javascript-error-c00c023f

When making an XMLHttpRequest in IE9, it will still go ahead and call the `onreadystatechange` handler with `readyState === 4`. Then when trying to access a property of the XHR, it dies with a wonderfully cryptic `SCRIPT575: Could not complete the operation due to error c00c023f.`
