### PR TITLE
fix: xhr.withCredentials is initially `false`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -8,20 +8,15 @@ var Request = module.exports = function (xhr, params) {
     self.writable = true;
     self.xhr = xhr;
     self.body = [];
-    
+
     self.uri = (params.scheme || 'http') + '://'
         + params.host
         + (params.port ? ':' + params.port : '')
         + (params.path || '/')
     ;
-    
-    if (typeof params.withCredentials === 'undefined') {
-        params.withCredentials = true;
-    }
 
-    try { xhr.withCredentials = params.withCredentials }
-    catch (e) {}
-    
+    xhr.withCredentials = params.withCredentials || false;
+
     xhr.open(
         params.method || 'GET',
         self.uri,

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -68,7 +68,7 @@ test('Test withCredentials param', function(t) {
   t.equal( request.xhr.withCredentials, true, 'xhr.withCredentials should be true');
 
   var request = http.request({ url: url }, noop);
-  t.equal( request.xhr.withCredentials, true, 'xhr.withCredentials should be true');
+  t.equal( request.xhr.withCredentials, false, 'xhr.withCredentials should be false');
 
   t.end();
 });


### PR DESCRIPTION
According to the [XMLHttpRequest2 spec](http://www.w3.org/TR/XMLHttpRequest2/#the-withcredentials-attribute),
`xhr.withCredentials` should be initially `false`. http-browserify sets this
flag to `true` by default which disobeys the spec. This leads to browser errors when
making CORS requests to domains that have wildcards in their
Access-Control-Allow-Origin header.

http-browserify should attempt to follow the spec by default. In this case,
that means setting `withCredentails` to `false` initially, and then allowing
the user to override that in the passing in `params`.

Maybe it is possible to auto-detect when [user credentials](http://www.w3.org/TR/XMLHttpRequest2/#user-credentials)
are being sent and then set the `withCredentials` flag from there.

Somewhat related to #35 (the committer there expressed concern about
`withCredentials` being `true` when unintialzed as well).
