### PR TITLE
responseType support

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -22,6 +22,9 @@ var Request = module.exports = function (xhr, params) {
     try { xhr.withCredentials = params.withCredentials }
     catch (e) {}
     
+    if (params.responseType) try { xhr.responseType = params.responseType }
+    catch (e) {}
+    
     xhr.open(
         params.method || 'GET',
         self.uri,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-browserify",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "http module compatability for browserify",
   "main": "index.js",
   "browserify": "index.js",


### PR DESCRIPTION
makes it much easier to handle binary data (xhr.responseType = 'arraybuffer')
