### PR TITLE
Make it possible to pass arguments to the xhr object

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,10 @@ http.request = function (params, cb) {
         params.host = params.host.split(':')[0];
     }
     if (!params.port) params.port = params.scheme == 'https' ? 443 : 80;
-    
-    var req = new Request(new xhrHttp, params);
+
+    var xhrParams = params.xhrParams || {};
+
+    var req = new Request(new xhrHttp(xhrParams), params);
     if (cb) req.on('response', cb);
     return req;
 };

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -7,9 +7,15 @@ global.window = {
 };
 
 var noop = function() {};
-global.window.XMLHttpRequest = function() {
+global.window.XMLHttpRequest = function(xhrParams) {
   this.open = noop;
   this.send = noop;
+
+  if(!xhrParams) return;
+
+  Object.keys(xhrParams).forEach(function(key) {
+      this[key] = xhrParams[key];
+  }.bind(this));
 };
 
 var test = require('tape').test;
@@ -71,4 +77,18 @@ test('Test withCredentials param', function(t) {
   t.equal( request.xhr.withCredentials, true, 'xhr.withCredentials should be true');
 
   t.end();
+});
+
+test('Test additional xhr params', function(t) {
+    var request = http.request({
+        url: '/api/foo',
+        xhrParams: {
+            mozSystem: true,
+            mozAnon: true
+        }
+    });
+
+    t.equal( request.xhr.mozSystem, true, 'xhr.mozSystem should be true');
+    t.equal( request.xhr.mozAnon, true, 'mozAnon should be true');
+    t.end();
 });


### PR DESCRIPTION
With Firefox it is possible to pass additional arguments to `XMLHttpRequest` (e.g. to enable [`systemXHR`](https://developer.mozilla.org/en-US/Apps/Reference#systemXHR) under Firefox OS).

These parameters are explained [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Non-standard_properties).

This change makes it possible to specify arguments to `XMLHttpRequest` by setting `params.xhrParams`.
