### PR TITLE
Bug fix for Request port duplication

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -10,7 +10,7 @@ var Request = module.exports = function (xhr, params) {
     self.body = [];
     
     self.uri = (params.scheme || 'http') + '://'
-        + params.host
+        + (params.port ? params.host.replace(/:\d+$/,'') : params.host )
         + (params.port ? ':' + params.port : '')
         + (params.path || '/')
     ;


### PR DESCRIPTION
Bug, given a parsed URL, e.g... 
{
   host : 'localhost:3000',
   port : '3000'
}

The Request object will append the ports twice, which is a bug.

See fix...
