### PR TITLE
Use XDomainRequest in browsers which can't CORS with XMLHttpRequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ http.request = function (params, cb) {
     if (!params.host) params.host = window.location.host.split(':')[0];
     if (!params.port) params.port = window.location.port;
     
-    var req = new Request(new xhrHttp, params);
+    var req = new Request(new xhrHttp(params), params);
     if (cb) req.on('response', cb);
     return req;
 };
@@ -22,9 +22,12 @@ http.get = function (params, cb) {
 http.Agent = function () {};
 http.Agent.defaultMaxSockets = 4;
 
-var xhrHttp = (function () {
+var xhrHttp = function (params) {
     if (typeof window === 'undefined') {
         throw new Error('no window object present');
+    }
+    else if (params.host != window.location.host.split(':')[0] && window.XDomainRequest) {
+        return window.XDomainRequest;
     }
     else if (window.XMLHttpRequest) {
         return window.XMLHttpRequest;
@@ -56,4 +59,4 @@ var xhrHttp = (function () {
     else {
         throw new Error('ajax not supported in this browser');
     }
-})();
+};

--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ http.request = function (params, cb) {
         params.host = params.host.split(':')[0];
     }
     if (!params.port) params.port = params.scheme == 'https' ? 443 : 80;
-    
-    var req = new Request(new xhrHttp(params), params);
+    var req = new Request(new (xhrHttp(params)), params);
     if (cb) req.on('response', cb);
     return req;
 };
@@ -79,7 +78,7 @@ var xhrHttp = function (params) {
     else {
         throw new Error('ajax not supported in this browser');
     }
-})();
+};
 
 http.STATUS_CODES = {
     100 : 'Continue',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var http = module.exports;
 var EventEmitter = require('events').EventEmitter;
 var Request = require('./lib/request');
-var url = require('url')
+var url = require('url');
 
 http.request = function (params, cb) {
     if (typeof params === 'string') {
@@ -45,7 +45,8 @@ var xhrHttp = function (params) {
     if (typeof window === 'undefined') {
         throw new Error('no window object present');
     }
-    else if (params.host != window.location.host.split(':')[0] && window.XDomainRequest) {
+    else if (shouldXDR(params)) {
+        // NOTE: params.withCredentials will be ignored: http://bit.ly/ie9nocors
         return window.XDomainRequest;
     }
     else if (window.XMLHttpRequest) {
@@ -138,3 +139,12 @@ http.STATUS_CODES = {
     510 : 'Not Extended',               // RFC 2774
     511 : 'Network Authentication Required' // RFC 6585
 };
+
+// whether the request with params should use XDomainRequest
+function shouldXDR(params) {
+    var crossOrigin = params.host != window.location.host.split(':')[0];
+    var xhrExists = typeof XMLHttpRequest !== 'undefined';
+    var xdrExists = typeof XDomainRequest !== 'undefined';
+    var noCORS = xhrExists && ! ('withCredentials' in new XMLHttpRequest);
+    return crossOrigin && noCORS && xdrExists;
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -32,7 +32,24 @@ var Request = module.exports = function (xhr, params) {
         self.emit('response', res);
     });
     
+
+    xhr.onprogress = function() {  // IE XDR
+        xhr.readyState = 2;
+        res.getAllResponseHeaders = function() {
+          return 'Content-Type: ' + xhr.contentType;  // This is the only header available
+        };
+        res.handle(xhr);
+    }
     xhr.onreadystatechange = function () {
+        res.handle(xhr);
+    };
+    xhr.onload = function() {  // IE XDR
+        xhr.readyState = 4;
+        res.handle(xhr);
+    };
+    xhr.onerror = function() {  // IE XDR
+        xhr.readyState = 3;
+        xhr.error = 'Unknown error';
         res.handle(xhr);
     };
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -14,7 +14,7 @@ var Request = module.exports = function (xhr, params) {
         + (params.port ? ':' + params.port : '')
         + (params.path || '/')
     ;
-    
+
     if (typeof params.withCredentials === 'undefined') {
         params.withCredentials = true;
     }
@@ -53,34 +53,59 @@ var Request = module.exports = function (xhr, params) {
         self.emit('close');
     });
     
-    res.on('ready', function () {
+    res.once('ready', function () {
         self.emit('response', res);
     });
-    
 
-    xhr.onprogress = function() {  // IE XDR
-        xhr.readyState = 2;
-        res.getAllResponseHeaders = function() {
-          return 'Content-Type: ' + xhr.contentType;  // This is the only header available
-        };
-        res.handle(xhr);
-    }
     xhr.onreadystatechange = function () {
         // Fix for IE9 bug
         // SCRIPT575: Could not complete the operation due to error c00c023f
         // It happens when a request is aborted, calling the success callback anyway with readyState === 4
         if (xhr.__aborted) return;
+        if (xhr.readyState === 4 && xhr.status === 0) {
+            // onerror will fire and its an error so there should be no res
+            return;
+        }
         res.handle(xhr);
     };
-    xhr.onload = function() {  // IE XDR
-        xhr.readyState = 4;
+
+    xhr.onerror = function() {
+        // http://www.w3.org/TR/XMLHttpRequest/#the-status-attribute
+        // there was an error making the request
+        // In node, this means the request should emit 'error' and no response
+        // should ever be created
+        if (xhr.status === 0) {
+            // error flag is set so no response should be gotten
+            requestError(new Error("XHR is done (state 4) but error flag is set (status 0)"));
+            return;
+        }
+        else if ( ! xhr.status) {
+            // If falsy but not 0, it's an IE XDR
+            requestError(new Error('XDomainRequest Error'));
+            return;
+        }
+
+        xhr.error = xhr.error || 'Unknown error';
         res.handle(xhr);
+
+        function requestError(err) {
+            self.emit('error', err);
+            self.emit('close');
+        }
     };
-    xhr.onerror = function() {  // IE XDR
-        xhr.readyState = 3;
-        xhr.error = 'Unknown error';
-        res.handle(xhr);
-    };
+
+    if (window.XDomainRequest && xhr instanceof window.XDomainRequest) {
+        // IE XDomainRequest has onload but not onreadystatechange
+        // Raised when the object has been completely received from the server.
+        // http://msdn.microsoft.com/en-us/library/ie/ms536942(v=vs.85).aspx
+        xhr.onload = function() {  // IE XDR
+            res.handle(xhr);
+        };
+        // IE sometimes fails if you don't specify every handler.
+        // https://github.com/matthewwithanm/httpplease.js/blob/861b26a9916543ff34963192d734da4c06603d0b/lib/index.js#L94
+        xhr.onprogress = function () {};
+        xhr.ontimeout = function () {};
+    }
 };
 
 inherits(Request, Stream);

--- a/lib/response.js
+++ b/lib/response.js
@@ -87,10 +87,13 @@ Response.prototype.handle = function (res) {
         }
     }
     else if (res.readyState === 4) {
-        if (!this.statusCode) {
-            this.statusCode = res.status;
-            this.emit('ready');
+        this.statusCode = res.status;
+        // statusCode 0 means the error flag is set on the request
+        // and thus there is no response to handle
+        if (this.statusCode === 0) {
+            return;
         }
+        this.emit('ready');
         this._emitData(res);
         
         if (res.error) {
@@ -98,6 +101,17 @@ Response.prototype.handle = function (res) {
         }
         else this.emit('end');
         
+        this.emit('close');
+    }
+    else if (isXDomainRequest(res)) {
+        // XDomainRequest wil only load if it got a 200 statusCode
+        // http://bugs.jquery.com/ticket/8283
+        if (!this.statusCode) {
+            this.statusCode = 200;
+        }
+        this.emit('ready');
+        this._emitData(res);
+        this.emit('end');
         this.emit('close');
     }
 };
@@ -118,3 +132,8 @@ Response.prototype._emitData = function (res) {
 var isArray = Array.isArray || function (xs) {
     return Object.prototype.toString.call(xs) === '[object Array]';
 };
+
+function isXDomainRequest(res) {
+    var XDomainRequest = window.XDomainRequest;
+    return XDomainRequest && res instanceof XDomainRequest;
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "http-browserify",
+  "name": "http-browserify-xdr",
   "version": "1.4.1",
   "description": "http module compatability for browserify",
   "main": "index.js",

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,19 +1,28 @@
-# http-browserify
+# http-browserify-xdr
 
 The
-[http](http://nodejs.org/docs/v0.4.10/api/all.html#hTTP) module from node.js,
-but for browsers.
+[http](http://nodejs.org/docs/v0.4.10/api/all.html#hTTP) module from browserify,
+but for browsers that can only do cross-origin requests with XDomainRequest (IE8 & IE9).
 
-When you `require('http')` in
-[browserify](http://github.com/substack/node-browserify),
-this module will be loaded.
+The out-of-the-box [http-browserify] does not work for cross-origin requests with XDomainRequest, and [an open issue](https://github.com/substack/http-browserify/pull/3) has gone unresponded to for almost 3 years.
+
+Use this in your browserify project by adding the following to your package.json:
+```json
+"browser": {
+    "http": "http-browserify-xdr"
+}
+```
+
+Note: XDomainRequests [cannot send cookies](http://bit.ly/ie9nocors), so 'withCredentials' options will be ignored. The way to do cross-origin requests withCredentials in these browsers is, well, you can't. You have to open an iframe serving a src on the origin you want to request, then postMessage into it, have it make the request, then postMessage the response out. See [sockjs-client](https://github.com/sockjs/sockjs-client#supported-transports-by-browser-html-served-from-http-or-https) for a referenc eimplementation of that.
+
+The following is the original http-browserify README because the API is the same.
 
 # example
 
 ``` js
 var http = require('http');
 
-http.get({ path : '/beep' }, function (res) {
+http.get({ host: 'anotherorigin.com', path : '/beep' }, function (res) {
     var div = document.getElementById('result');
     div.innerHTML += 'GET /beep<br>';
     
@@ -108,11 +117,11 @@ You can do:
 
 ````javascript
 var bundle = browserify({
-    require : { http : 'http-browserify' }
+    require : { http : 'http-browserify-xdr' }
 });
 ````
 
-in order to map "http-browserify" over `require('http')` in your browserified
+in order to map "http-browserify-xdr" over `require('http')` in your browserified
 source.
 
 # install
@@ -120,7 +129,7 @@ source.
 With [npm](https://npmjs.org) do:
 
 ```
-npm install http-browserify
+npm install http-browserify-xdr
 ```
 
 # license

--- a/readme.markdown
+++ b/readme.markdown
@@ -13,6 +13,8 @@ Use this in your browserify project by adding the following to your package.json
 }
 ```
 
+I intend to have version numbers here mirror http-browserify changes (>= 1.4.1) until @substack merges my pull request.
+
 Note: XDomainRequests [cannot send cookies](http://bit.ly/ie9nocors), so 'withCredentials' options will be ignored. The way to do cross-origin requests withCredentials in these browsers is, well, you can't. You have to open an iframe serving a src on the origin you want to request, then postMessage into it, have it make the request, then postMessage the response out. See [sockjs-client](https://github.com/sockjs/sockjs-client#supported-transports-by-browser-html-served-from-http-or-https) for a referenc eimplementation of that.
 
 The following is the original http-browserify README because the API is the same.

--- a/readme.markdown
+++ b/readme.markdown
@@ -2,7 +2,7 @@
 
 The
 [http](http://nodejs.org/docs/v0.4.10/api/all.html#hTTP) module from browserify,
-but for browsers that can only do cross-origin requests with XDomainRequest (IE8 & IE9).
+but supporting browsers that can only do cross-origin requests with XDomainRequest (IE8 & IE9).
 
 The out-of-the-box [http-browserify] does not work for cross-origin requests with XDomainRequest, and [an open issue](https://github.com/substack/http-browserify/pull/3) has gone unresponded to for almost 3 years.
 


### PR DESCRIPTION
#3 has been open and unresponded to for three years. I +1d it, but went to use that fork and realized it didn't really even work.

This pull request is up to date with 1.4.1, and I've tested it a good amount in IE9 while working on https://github.com/gobengo/chronos-stream, and more important will continue to maintain it for my job @Livefyre in the forseeable future.

@substack, now with some legwork into this, will you please respond and say whether you find this change in scope appropriate for http-browserify and the OOB 'http' builtin?

If you never want it in the builtin, we can close this PR and folks can just use [http-browserify-xdr](https://github.com/gobengo/http-browserify-xdr) manually if they want. But at least this issue will be here for posterity.

If you are supportive, I'll get the README changes out of this PR that I made.
