### PR TITLE
Add support for XHR2 send with Blob/ArrayBuffer/FormData (fixes #43)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -134,6 +134,9 @@ Request.prototype.end = function (s) {
         }
         this.xhr.send(body);
     }
+    else if (isXHR2Compatible(this.body[0])) {
+        this.xhr.send(this.body[0]);
+    }
     else {
         var body = '';
         for (var i = 0; i < this.body.length; i++) {
@@ -189,4 +192,10 @@ var indexOf = function (xs, x) {
         if (xs[i] === x) return i;
     }
     return -1;
+};
+
+var isXHR2Compatible = function (obj) {
+    return obj instanceof window.Blob
+        || obj instanceof window.ArrayBuffer
+        || obj instanceof window.FormData;
 };

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -12,6 +12,10 @@ global.window.XMLHttpRequest = function() {
   this.send = noop;
 };
 
+global.window.FormData = function () {};
+global.window.Blob = function () {};
+global.window.ArrayBuffer = function () {};
+
 var test = require('tape').test;
 var http = require('../index.js');
 
@@ -71,4 +75,27 @@ test('Test withCredentials param', function(t) {
   t.equal( request.xhr.withCredentials, true, 'xhr.withCredentials should be true');
 
   t.end();
+});
+
+test('Test POST XHR2 types', function(t) {
+  t.plan(3);
+  var url = '/api/foo';
+
+  var request = http.request({ url: url, method: 'POST' }, noop);
+  request.xhr.send = function (data) {
+    t.ok(data instanceof global.window.ArrayBuffer, 'data should be instanceof ArrayBuffer');
+  };
+  request.end(new global.window.ArrayBuffer());
+
+  request = http.request({ url: url, method: 'POST' }, noop);
+  request.xhr.send = function (data) {
+    t.ok(data instanceof global.window.Blob, 'data should be instanceof Blob');
+  };
+  request.end(new global.window.Blob());
+
+  request = http.request({ url: url, method: 'POST' }, noop);
+  request.xhr.send = function (data) {
+    t.ok(data instanceof global.window.FormData, 'data should be instanceof FormData');
+  };
+  request.end(new global.window.FormData());
 });


### PR DESCRIPTION
If write/end is called for the first time with an instance of `Blob`, `ArrayBuffer`, or `FormData`, call `xhr.send` directly with the object.
