### PR TITLE
Add reference to request object as property on response

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -53,6 +53,7 @@ var Request = module.exports = function (xhr, params) {
     }
 
     var res = new Response;
+    res.req = self;
     res.on('close', function () {
         self.emit('close');
     });

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -112,3 +112,17 @@ test('Test POST XHR2 types', function(t) {
   };
   request.end(new global.FormData());
 });
+
+test('Test response has reference to request object', function(t) {
+  t.plan(1);
+  var url = '/api/foo';
+
+  var request = http.request({ url: url });
+  request.on('response', function (res) {
+    t.equal(res.req, request, 'response should have reference to request object');
+  });
+  request.xhr.readyState = 4;
+  request.xhr.responseType = 'meat';
+  request.xhr.responseText = '';
+  request.xhr.onreadystatechange();
+});


### PR DESCRIPTION
Node http responses have a convenient reference to the request object `req`, so I added it here as well.
