### PR TITLE
Set correct path and method properties on the request object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -8,6 +8,8 @@ var Request = module.exports = function (xhr, params) {
     self.writable = true;
     self.xhr = xhr;
     self.body = [];
+    self.method = params.method || 'GET';
+    self.path = params.path || '/'
     
     self.uri = (params.protocol || 'http:') + '//'
         + params.host
@@ -26,7 +28,7 @@ var Request = module.exports = function (xhr, params) {
     catch (e) {}
     
     xhr.open(
-        params.method || 'GET',
+        self.method,
         self.uri,
         true
     );

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -112,3 +112,17 @@ test('Test POST XHR2 types', function(t) {
   };
   request.end(new global.FormData());
 });
+
+test('Test request has correct method and path properties', function(t) {
+  var path = '/api/foo?hello=world';
+
+  var request = http.request(path);
+  t.equal(request.path, path, 'path should be correct');
+  t.equal(request.method, 'GET', 'method should be correct');
+
+  request = http.request({ path: path, method: 'POST' });
+  t.equal(request.path, path, 'path should be correct');
+  t.equal(request.method, 'POST', 'method should be correct');
+
+  t.end();
+});


### PR DESCRIPTION
Node http sets `path` and `method` properties on the request object.
