### PR TITLE
Fix xhr.responseType set before xhr.open

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -21,15 +21,15 @@ var Request = module.exports = function (xhr, params) {
 
     try { xhr.withCredentials = params.withCredentials }
     catch (e) {}
-    
-    if (params.responseType) try { xhr.responseType = params.responseType }
-    catch (e) {}
-    
+
     xhr.open(
         params.method || 'GET',
         self.uri,
         true
     );
+
+    if (params.responseType) try { xhr.responseType = params.responseType }
+    catch (e) {}
 
     xhr.onerror = function(event) {
         self.emit('error', new Error('Network error'));


### PR DESCRIPTION
Not a problem with Chrome, but in Firefox setting it before doesn't work.
See: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest#Usage
