### PR TITLE
Behave more like Node http

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -35,6 +35,8 @@ var Request = module.exports = function (xhr, params) {
         self.emit('error', new Error('Network error'));
     };
 
+    if (!params.encoding) xhr.responseType = 'arraybuffer';
+
     self._headers = {};
     
     if (params.headers) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -105,7 +105,9 @@ Response.prototype.handle = function (res) {
 Response.prototype._emitData = function (res) {
     var respBody = this.getResponse(res);
     if (respBody.toString().match(/ArrayBuffer/)) {
-        this.emit('data', new Uint8Array(respBody, this.offset));
+        var arrayBuffer = new Uint8Array(respBody, this.offset);
+        var buffer = new Buffer(arrayBuffer, this.offset);
+        this.emit('data', buffer);
         this.offset = respBody.byteLength;
         return;
     }


### PR DESCRIPTION
Emit Buffers instead of ArrayBuffers and if encoding is null return Buffer.
These also allow to have [request](http://github.com/mikeal/request) behave the same way on the browser and server.
