### PR TITLE
Respect protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,14 @@ http.request = function (params, cb) {
         params.host = params.hostname;
     }
 
-    if (params.protocol) {
-        params.scheme = params.protocol.split(':')[0];
+    if (!params.protocol) {
+        if (params.scheme) {
+            params.protocol = params.scheme + ':';
+        } else {
+            params.protocol = window.location.protocol;
+        }
     }
 
-    if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
     if (!params.host) {
         params.host = window.location.hostname || window.location.host;
     }
@@ -29,7 +32,7 @@ http.request = function (params, cb) {
         }
         params.host = params.host.split(':')[0];
     }
-    if (!params.port) params.port = params.scheme == 'https' ? 443 : 80;
+    if (!params.port) params.port = params.protocol == 'https:' ? 443 : 80;
     
     var req = new Request(new xhrHttp, params);
     if (cb) req.on('response', cb);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,11 @@ http.request = function (params, cb) {
     if (!params.host && params.hostname) {
         params.host = params.hostname;
     }
-    
+
+    if (params.protocol) {
+        params.scheme = params.protocol.split(':')[0];
+    }
+
     if (!params.scheme) params.scheme = window.location.protocol.split(':')[0];
     if (!params.host) {
         params.host = window.location.hostname || window.location.host;

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,7 +9,7 @@ var Request = module.exports = function (xhr, params) {
     self.xhr = xhr;
     self.body = [];
     
-    self.uri = (params.scheme || 'http') + '://'
+    self.uri = (params.protocol || 'http:') + '//'
         + params.host
         + (params.port ? ':' + params.port : '')
         + (params.path || '/')

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -48,6 +48,20 @@ test('Test full url object', function(t) {
 
 });
 
+test('Test alt protocol', function(t) {
+  var params = {
+    protocol: "foo:",
+    hostname: "localhost",
+    port: "3000",
+    path: "/bar"
+  };
+
+  var request = http.get(params, noop);
+
+  t.equal( request.uri, 'foo://localhost:3000/bar', 'Url should be correct');
+  t.end();
+
+});
 
 test('Test string as parameters', function(t) {
   var url = '/api/foo';


### PR DESCRIPTION
When the first arg to `http.request` is a string, it is passed to `url.parse`.  This returns an object with a `protocol` property (and no `scheme`).  In this case, the `protocol` is ignored (in favor of `window.location.protocol.split(':')[0]`).

The first change here respects the `protocol` if it is provided.  The second change makes it so `Request` expects a `protocol` instead of `scheme`.  I can rework either if needed.

Where this issue arose for me was in a site using https when I needed to (temporarily) access a resource via http.  I provided a http URL to `http.get` and it generated a https URL based on `window.location.protocol` (instead of respecting the protocol from `url.parse`).
