### PR TITLE
Fix exception when setting XHR responseType parameter

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -22,14 +22,19 @@ var Request = module.exports = function (xhr, params) {
     try { xhr.withCredentials = params.withCredentials }
     catch (e) {}
     
-    if (params.responseType) try { xhr.responseType = params.responseType }
-    catch (e) {}
-    
     xhr.open(
         params.method || 'GET',
         self.uri,
         true
     );
+
+    if (params.responseType) {
+        try {
+            xhr.responseType = params.responseType
+        } catch (e) {
+            self.emit('error', e);
+        }
+    }
 
     xhr.onerror = function(event) {
         self.emit('error', new Error('Network error'));

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -86,3 +86,11 @@ test('Test withCredentials param', function(t) {
 
   t.end();
 });
+
+test('Test responseType param', function(t) {
+  var url = '/api/binary-endpoint';
+  var request = http.request({url: url, responseType: 'arraybuffer'}, noop);
+  t.equal(request.xhr.responseType, 'arraybuffer', 'xhr.responseType should be set');
+  t.end();
+});
+


### PR DESCRIPTION
According to the XHR spec (http://xhr.spec.whatwg.org/#the-responsetype-attribute) and
https://bugzilla.mozilla.org/show_bug.cgi?id=707484 it is legal to set the responseType attribute
before opening the request. However, this doesn't work with current versions of Firefox and results
in an exception.

Work around this issue by setting the xhr.responseType attribute only
after opening the request.

Also if the caller explicitly specifies a desired response type, report
an error instead of silently returning an unexpected data type if the
xhr.responseType assignment fails.

Fixes #65
