### PR TITLE
Allow test frameworks to mock out XMLHttpRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var http = module.exports;
 var EventEmitter = require('events').EventEmitter;
 var Request = require('./lib/request');
-var url = require('url')
+var url = require('url');
 
 http.request = function (params, cb) {
     if (typeof params === 'string') {
@@ -33,8 +33,8 @@ http.request = function (params, cb) {
         params.host = params.host.split(':')[0];
     }
     if (!params.port) params.port = params.protocol == 'https:' ? 443 : 80;
-    
-    var req = new Request(new xhrHttp, params);
+     
+    var req = new Request(new (getXMLHttpRequest()), params);
     if (cb) req.on('response', cb);
     return req;
 };
@@ -49,7 +49,7 @@ http.get = function (params, cb) {
 http.Agent = function () {};
 http.Agent.defaultMaxSockets = 4;
 
-var xhrHttp = (function () {
+var getXMLHttpRequest = function () {
     if (typeof window === 'undefined') {
         throw new Error('no window object present');
     }
@@ -78,12 +78,12 @@ var xhrHttp = (function () {
             }
             catch (e) {}
         }
-        throw new Error('ajax not supported in this browser')
+        throw new Error('ajax not supported in this browser');
     }
     else {
         throw new Error('ajax not supported in this browser');
     }
-})();
+};
 
 http.STATUS_CODES = {
     100 : 'Continue',

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ http.request = function (params, cb) {
         params.host = params.host.split(':')[0];
     }
     if (!params.port) params.port = params.protocol == 'https:' ? 443 : 80;
-     
+
     var req = new Request(new (getXMLHttpRequest()), params);
     if (cb) req.on('response', cb);
     return req;


### PR DESCRIPTION
- instead of saving a reference to global.XMLHttpRequest / ActiveX,
  return the reference each time http.request() is called
- performance impact should be negligible
- potential concerns about malicious injected scripts hijacking
  XMLHttpRequest... considering jQuery initializes XHR() the same way,
  it shouldn't be an issue.
- normalized some semicolon usage
- fixes https://github.com/substack/http-browserify/issues/68
