### PR TITLE
Set the xhr.withCredentials flag after xhr.open()

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -19,9 +19,6 @@ var Request = module.exports = function (xhr, params) {
         params.withCredentials = true;
     }
 
-    try { xhr.withCredentials = params.withCredentials }
-    catch (e) {}
-    
     if (params.responseType) try { xhr.responseType = params.responseType }
     catch (e) {}
     
@@ -30,6 +27,8 @@ var Request = module.exports = function (xhr, params) {
         self.uri,
         true
     );
+
+    xhr.withCredentials = params.withCredentials;
 
     xhr.onerror = function(event) {
         self.emit('error', new Error('Network error'));


### PR DESCRIPTION
Setting `xhr.withCredentials = true` before the `xhr.open()` call throws an InvalidStateError in IE10 (and possibly other browsers too). This behaviour is actually according to spec: http://www.w3.org/TR/XMLHttpRequest2/#the-withcredentials-attribute.

I can't see any reason for the try catch around it either (other than making it harder to spot errors), so I removed it too. I'm happy to bring it back if there are good reasons for it.
