### PR TITLE
Update documentation to match node http module

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -81,9 +81,11 @@ Close and send the request body, optionally with additional `data` to append.
 
 # response methods
 
-## res.getHeader(key)
+## res.headers
 
-Return an http header, if set. `key` is case-insensitive.
+The response headers object.
+
+Read only map of header names and values. Header names are lower-cased.
 
 # response attributes
 


### PR DESCRIPTION
See #71. The Node http module's response object has `response.headers`, not `response.getHeader()`. The _http-browserify_ module provides both, but previously only documented `response.getHeader()`. This changes the documentation to document `response.headers` instead. The `response.getHeader()` function is left undocumented as technically it does not match the node http module implementation.
