### PR TITLE
Give to FF a chance to set the ‘xhr.responseType’

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -22,14 +22,14 @@ var Request = module.exports = function (xhr, params) {
     try { xhr.withCredentials = params.withCredentials }
     catch (e) {}
     
-    if (params.responseType) try { xhr.responseType = params.responseType }
-    catch (e) {}
-    
     xhr.open(
         params.method || 'GET',
         self.uri,
         true
     );
+
+    if (params.responseType) try { xhr.responseType = params.responseType }
+    catch (e) {}
 
     xhr.onerror = function(event) {
         self.emit('error', new Error('Network error'));

--- a/lib/response.js
+++ b/lib/response.js
@@ -104,12 +104,12 @@ Response.prototype.handle = function (res) {
 
 Response.prototype._emitData = function (res) {
     var respBody = this.getResponse(res);
-    if (respBody.toString().match(/ArrayBuffer/)) {
+    if (respBody && respBody.toString().match(/ArrayBuffer/)) {
         this.emit('data', new Uint8Array(respBody, this.offset));
         this.offset = respBody.byteLength;
         return;
     }
-    if (respBody.length > this.offset) {
+    if (respBody && respBody.length > this.offset) {
         this.emit('data', respBody.slice(this.offset));
         this.offset = respBody.length;
     }


### PR DESCRIPTION
Give to FireFox a chance to set the xhr.responseType = 'arraybuffer' on async request.
See also: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
