### PR TITLE
defer detection of XHR

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ http.request = function (params, cb) {
         params.host = params.host.split(':')[0];
     }
     if (!params.port) params.port = params.protocol == 'https:' ? 443 : 80;
-    
+
     var req = new Request(new xhrHttp, params);
     if (cb) req.on('response', cb);
     return req;
@@ -49,41 +49,48 @@ http.get = function (params, cb) {
 http.Agent = function () {};
 http.Agent.defaultMaxSockets = 4;
 
-var xhrHttp = (function () {
-    if (typeof window === 'undefined') {
-        throw new Error('no window object present');
-    }
-    else if (window.XMLHttpRequest) {
-        return window.XMLHttpRequest;
-    }
-    else if (window.ActiveXObject) {
-        var axs = [
-            'Msxml2.XMLHTTP.6.0',
-            'Msxml2.XMLHTTP.3.0',
-            'Microsoft.XMLHTTP'
-        ];
-        for (var i = 0; i < axs.length; i++) {
-            try {
-                var ax = new(window.ActiveXObject)(axs[i]);
-                return function () {
-                    if (ax) {
-                        var ax_ = ax;
-                        ax = null;
-                        return ax_;
-                    }
-                    else {
-                        return new(window.ActiveXObject)(axs[i]);
-                    }
-                };
+var xhrDetected = null;
+var xhrHttp = function() {
+    if (xhrDetected) {
+        return new xhrDetected;
+    } else {
+        return new (xhrDetected = (function () {
+            if (typeof window === 'undefined') {
+                throw new Error('no window object present');
             }
-            catch (e) {}
-        }
-        throw new Error('ajax not supported in this browser')
+            else if (window.XMLHttpRequest) {
+                return window.XMLHttpRequest;
+            }
+            else if (window.ActiveXObject) {
+                var axs = [
+                    'Msxml2.XMLHTTP.6.0',
+                    'Msxml2.XMLHTTP.3.0',
+                    'Microsoft.XMLHTTP'
+                ];
+                for (var i = 0; i < axs.length; i++) {
+                    try {
+                        var ax = new(window.ActiveXObject)(axs[i]);
+                        return function () {
+                            if (ax) {
+                                var ax_ = ax;
+                                ax = null;
+                                return ax_;
+                            }
+                            else {
+                                return new(window.ActiveXObject)(axs[i]);
+                            }
+                        };
+                    }
+                    catch (e) {}
+                }
+                throw new Error('ajax not supported in this browser')
+            }
+            else {
+                throw new Error('ajax not supported in this browser');
+            }
+        })());
     }
-    else {
-        throw new Error('ajax not supported in this browser');
-    }
-})();
+}
 
 http.STATUS_CODES = {
     100 : 'Continue',


### PR DESCRIPTION
Ran into an issue with a tape-like pattern:

```
$ browserify-like-bundler tests/index.js | node
```

This package was detecting if the window object was present before my jsdom shim could execute (and therefore expose window/document globals). I deferred the execution of the detection until the first call to compensate.
