### PR TITLE
make sure response headers are there

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -87,6 +87,7 @@ Response.prototype.handle = function (res) {
         }
     }
     else if (res.readyState === 4) {
+        if (!this.headers) this.headers = parseHeaders(res);
         if (!this.statusCode) {
             this.statusCode = res.status;
             this.emit('ready');


### PR DESCRIPTION
I have a case when readyState 4 is the first one to hit, and headers ends up undefined
