### PR TITLE
FIX: port derivation with 'hostname' instead of 'host' given

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ http.request = function (params, cb) {
         params = url.parse(params)
     }
     if (!params) params = {};
-    if (!params.host && !params.port) {
-        params.port = parseInt(window.location.port, 10);
-    }
     if (!params.host && params.hostname) {
         params.host = params.hostname;
+    }
+    if (!params.host && !params.port) {
+        params.port = parseInt(window.location.port, 10);
     }
 
     if (!params.protocol) {

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -69,7 +69,7 @@ test('Test alt protocol', function(t) {
 test('Test host resolution with default port', function(t) {
   var url = {
     hostname: "external-host",
-	protocol: "https:"
+    protocol: "https:"
   };
 
   var request = http.get(url, noop);

--- a/test/request_url.js
+++ b/test/request_url.js
@@ -66,6 +66,19 @@ test('Test alt protocol', function(t) {
 
 });
 
+test('Test host resolution with default port', function(t) {
+  var url = {
+    hostname: "external-host",
+	protocol: "https:"
+  };
+
+  var request = http.get(url, noop);
+
+  t.equal( request.uri, 'https://external-host:443/', 'Url should be correct');
+  t.end();
+
+});
+
 test('Test string as parameters', function(t) {
   var url = '/api/foo';
   var request = http.get(url, noop);


### PR DESCRIPTION
## Problem:

When using 'hostname' instead of 'host' (as recommended by https://nodejs.org/api/http.html#http_http_request_options_callback) and omitting the 'port' option the request's port will get set to 'window.location.port' (independently of protocol and anything). This is not the case when using 'host' instead of 'hostname'.

_Example (actual status):_

``` javascript
window.location.port = 8080;
http.get({hostname: 'external-host', protocol: 'https'}); 
    // resolves to: 'https://external-host:8080/'
```

_Example (target status):_

``` javascript
window.location.port = 8080;
http.get({hostname: 'external-host', protocol: 'https'}); 
    // resolves to: 'https://external-host:443/'
```
## Solution:

Derive 'host' from 'hostname' before the port is resolved.
### Possible impact:

The original behavior MAY be correct for requests which target the same host and protocol as the current application. E.g. when running an application from 'http://localhost:8080' requests to `{hostname: 'localhost', protocol: 'http:', port: null}` COULD be resolved just as requests to `{protocol: 'http', port: null}` to target 'http://localhost:8080' (this pull requests resolves the former request to 'http://localhost:80').

Since I wasn't able to find any documentation about the intended behavior this is open to discussion. In my personal opinion omitting the 'port' option should always result in using default ports. Only in the special case when omitting both, hostname and port, the application may assume the request targets the host and port the current application was served from.

Unfortunately this behavior cannot be derived from node-http since the problem only occurs in browsers.
