### PR TITLE
Document withCredentials and its non standard default

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -41,6 +41,7 @@ where `opts` are:
 * `opts.host=window.location.host` - http host
 * `opts.port=window.location.port` - http port
 * `opts.responseType` - response type to set on the underlying xhr object
+* `opts.withCredentials` - sets `withCredentials` on underlying xhr object. Defaults to true, *which is opposite the default on `XMLHttpRequest`*  
 
 The callback will be called with the response object.
 


### PR DESCRIPTION
`withCredentials` defaults to `false` on `XMLHttpRequest`, but the opposite was chosen in this library. This can cause difficult to understand failures depending on the CORS headers returned by the server (it's an issue when calling the GitHub v3 API for example).

The alternative would be to default to `false` to stay consistent with `XMLHttpRequest`, but that is likely a breaking change for some downstream apps, and I am going to assume the current strategy was chosen for a reason.
