### PR TITLE
Maintain request header casing.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -36,6 +36,7 @@ var Request = module.exports = function (xhr, params) {
     };
 
     self._headers = {};
+    self._headerNames = {};
     
     if (params.headers) {
         var keys = objectKeys(params.headers);
@@ -78,6 +79,7 @@ inherits(Request, Stream);
 
 Request.prototype.setHeader = function (key, value) {
     this._headers[key.toLowerCase()] = value
+    this._headerNames[key.toLowerCase()] = key;
 };
 
 Request.prototype.getHeader = function (key) {
@@ -86,6 +88,7 @@ Request.prototype.getHeader = function (key) {
 
 Request.prototype.removeHeader = function (key) {
     delete this._headers[key.toLowerCase()]
+    delete this._headerNames[key.toLowerCase()]
 };
 
 Request.prototype.write = function (s) {
@@ -105,12 +108,13 @@ Request.prototype.end = function (s) {
     for (var i = 0; i < keys.length; i++) {
         var key = keys[i];
         var value = this._headers[key];
+        var name = this._headerNames[key];
         if (isArray(value)) {
             for (var j = 0; j < value.length; j++) {
-                this.xhr.setRequestHeader(key, value[j]);
+                this.xhr.setRequestHeader(name, value[j]);
             }
         }
-        else this.xhr.setRequestHeader(key, value)
+        else this.xhr.setRequestHeader(name, value)
     }
 
     if (this.body.length === 0) {


### PR DESCRIPTION
While headers are meant to be case sensitive, many servers do not
respect this.  Node maintains the casing of the request headers in order
to work with this and http-browserify should do likewise in order to be
consistent with the node implementation.

This patch maintains the casing with which the header was last set, e.g.
setting header "fOo", then header "Foo" will still only send one header,
but will use the final casing "Foo".  This is compatible with the [node implementation](https://github.com/nodejs/node/blob/85ab4a5f1281c4e1dd06450ac7bd3250326267fa/lib/_http_outgoing.js).
