### PR TITLE
Use "inherits" module instead of "util.inherits" on response.js

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1,12 +1,12 @@
 var Stream = require('stream');
-var util = require('util');
+var inherits = require('inherits');
 
 var Response = module.exports = function (res) {
     this.offset = 0;
     this.readable = true;
 };
 
-util.inherits(Response, Stream);
+inherits(Response, Stream);
 
 var capable = {
     streaming : true,


### PR DESCRIPTION
Use similar inheritance than it's already on request.js on response.js - which is using "inherits" module over "util.inherits".

The actual reason is to fix a Webpack related issue "util.inherits is not a function".
