### PR TITLE
fix unsafe header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -77,6 +77,7 @@ var Request = module.exports = function (xhr, params) {
 inherits(Request, Stream);
 
 Request.prototype.setHeader = function (key, value) {
+    if (!this.isSafeRequestHeader(key)) return;
     this._headers[key.toLowerCase()] = value
 };
 


### PR DESCRIPTION
It will throw exception when call `.setHeader` manauly.