### PR TITLE
updated to base64 of 1.0.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tape test/*.js"
   },
   "dependencies": {
-    "Base64": "~0.2.0",
+    "Base64": "~1.0.0",
     "inherits": "~2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I would like to update base64 version to the latest, `1.0.0` https://github.com/mathiasbynens/base64